### PR TITLE
bug: Se elimina el botón anterior en la primer pagina 

### DIFF
--- a/src/views/_pagination.html
+++ b/src/views/_pagination.html
@@ -2,7 +2,9 @@
     <nav class="pagination fs-5">
         <ul class="hstack gap-3">
             <li class="pagination__prev">
+                {% if currentPage != 1 %}
                 <a href="?page={{ currentPage - 1 }}">< Anterior</a>
+                {% endif %}
             </li>
 
             <li>

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -44,4 +44,14 @@ describe('Home Test', () => {
             .should('contain.text', '5 %');
     });
 
+    it('Deberia no mostrar el boton previous en la primer pagina ', () => {
+        cy.visit('/');
+        cy.get('.pagination__next > a').click();
+        cy.get('.pagination__prev > a').click();
+        cy.get('.pagination__prev > a').should('not.exist');
+
+    });
+
+    
+
 });


### PR DESCRIPTION
El boton "Anterior" en el paginador del home no se muestra en la primer pagina del listado de productos. 