### PR TITLE
bug: Se elimina el boton siguiente en la ultima pagina 

### DIFF
--- a/src/views/_pagination.html
+++ b/src/views/_pagination.html
@@ -12,7 +12,9 @@
             </li>
 
             <li class="pagination__next">
+                {% if currentPage < totalPages %}
                 <a href="?page={{ currentPage + 1 }}">Siguiente ></a>
+                {% endif %}
             </li>
         </ul>
     </nav>

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -44,4 +44,14 @@ describe('Home Test', () => {
             .should('contain.text', '5 %');
     });
 
+    it('Deberia no mostrar el boton next en la ultima pagina ', () => {
+        cy.visit('/');
+        cy.get('.pagination__next > a').click();
+        cy.url().should('include', 'page=2');
+        cy.get('.pagination__next > a').should('not.exist');
+
+
+
+    });
+
 });


### PR DESCRIPTION
Desaparece el botón que da la opción de ir a la siguiente pagina en la ultima pagina del paginador home que muestra un listado de productos. 